### PR TITLE
Add __stepname__ attribute to plugin __init__.

### DIFF
--- a/mapclientplugins/pointsourcestep/__init__.py
+++ b/mapclientplugins/pointsourcestep/__init__.py
@@ -19,5 +19,6 @@ This file is part of MAP Client. (http://launchpad.net/mapclient)
 """
 __version__ = '0.1.0'
 __author__ = 'Ju Zhang'
+__stepname__ = 'Point Source'
 
 from mapclientplugins.pointsourcestep import step


### PR DESCRIPTION
This attribute is used by the MAP-Client to keep track of all the currently installed plugins, without it a number of MAP-Client plugin manager methods do not function correctly.